### PR TITLE
Fix for Babel 7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function replace(value, original, replacement) {
 }
 
 function getReplacements(state) {
-  if (state.opts instanceof Array) {
+  if (state.opts.replacements && state.opts.replacements instanceof Array) {
     return state.opts;
   }
   return [state.opts];


### PR DESCRIPTION
Babel 7 doesn't allow an array to used as options.